### PR TITLE
BOJ_1260_DFS와_BFS / S2 / O

### DIFF
--- a/week03/BOJ_1260_DFS와_BFS/김지은.java
+++ b/week03/BOJ_1260_DFS와_BFS/김지은.java
@@ -1,0 +1,73 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int[][] graph;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int v = Integer.parseInt(st.nextToken());
+
+        graph = new int[n + 1][n + 1];
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            graph[x][y] = 1;
+            graph[y][x] = 1;
+        }
+
+        visited = new boolean[n + 1];
+        dfs(v);
+
+        System.out.println();
+
+        visited = new boolean[n + 1];
+        bfs(v);
+    }
+
+    public static void dfs(int v) {
+        visited[v] = true;
+
+        System.out.print(v + " ");
+
+        for (int n = 1; n < graph[v].length; n++) {
+            if (graph[v][n] != 0 && !visited[n])
+                dfs(n);
+        }
+
+    }
+
+    public static void bfs(int v) {
+        Queue<Integer> queue = new LinkedList<Integer>();
+
+        visited[v] = true;
+
+        queue.offer(v);
+
+        while (!queue.isEmpty()) {
+            int u = queue.poll();
+
+            System.out.print(u + " ");
+
+            for (int n = 1; n < graph[u].length; n++) {
+                if (graph[u][n] != 0 && !visited[n]) {
+                    visited[n] = true;
+                    queue.offer(n);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 사용한 자료구조 및 알고리즘
- 그래프
- DFS
- BFS

### 코드 설명
1. **그래프**
```java
for (int i = 0; i < m; i++) {
    st = new StringTokenizer(br.readLine());
    int x = Integer.parseInt(st.nextToken());
    int y = Integer.parseInt(st.nextToken());

    graph[x][y] = 1;
    graph[y][x] = 1;
}
```
간선의 밀도는 모르지만, 인접 노드를 탐색할 때 시간을 단축할 수 있어 그래프는 인접 행렬로 표현했습니다. 양방향 그래프이기 때문에 graph[x][y], graph[y][x] 모두 표시를 합니다.

2. **DFS**
```java
public static void dfs(int v) {
    visited[v] = true;

    System.out.print(v + " ");

    for (int n = 1; n < graph[v].length; n++) {
        if (graph[v][n] != 0 && !visited[n])
            dfs(n);
        }
}
```
DFS는 v를 방문했다고 표시한 후, 출력합니다. 그 다음, v의 인근 노드 중 방문하지 않은 노드를 재귀적으로 방문합니다.

3. **BFS**
```java
public static void bfs(int v) {
    Queue<Integer> queue = new LinkedList<Integer>();

    visited[v] = true;

    queue.offer(v);

    while (!queue.isEmpty()) {
        int u = queue.poll();

        System.out.print(u + " ");

        for (int n = 1; n < graph[u].length; n++) {
            if (graph[u][n] != 0 && !visited[n]) {
                visited[n] = true;
                queue.offer(n);
            }
        }
    }
}
```
BFS는 v를 방문했다고 표시한 후, queue에 삽입합니다. 큐가 비어있지 않다면, dequeue하고 dequeue한 노드의 인근 노드 중 방문하지 않은 노드를 방문 표시한 다음에 큐에 삽입합니다.

### 코드 리뷰 요청 사항
코드의 가독성이나 효율적인 부분에서 고쳐야하는 부분이 있을까요?