### PR TITLE
BOJ_2178_미로_탐색 / S1 / X

### DIFF
--- a/week03/BOJ_2178_미로_탐색/김민경.java
+++ b/week03/BOJ_2178_미로_탐색/김민경.java
@@ -1,0 +1,60 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.Queue;
+import java.util.LinkedList;
+
+public class Main {
+    static int[][] adj;
+    static boolean[][] visited;
+    static int n, m;
+    static int count = 0;
+    static int dx[]= {-1, 1, 0, 0};
+	static int dy[]= {0, 0, -1, 1};
+
+    static void bfs(int i, int j) {
+        Queue<int[]> queue = new LinkedList<>();
+		queue.offer(new int[] {i, j});
+        
+        while(!queue.isEmpty()) {
+            int q[] = queue.poll();
+            int qx = q[0];
+            int qy = q[1];
+
+            for(int k = 0; k < 4; k++) {
+                int x = qx + dx[k]; //상하
+                int y = qy + dy[k]; //좌우
+                    
+                if(x > 0 && y > 0 && x <= n && y <= m) {
+                    if(visited[x][y] == false && adj[x][y] == 1) {
+                        queue.offer(new int[] {x, y});
+        		        adj[x][y] = adj[qx][qy] + 1;
+                		visited[x][y] = true;
+                    }
+                }
+            }
+        }
+    }    
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+
+        adj = new int[n + 1][m + 1];
+        visited = new boolean[n + 1][m + 1];
+
+        for(int i = 1; i <= n; i++) {
+            String s = br.readLine();
+            for(int j = 1; j <= m; j++) {
+                adj[i][j] = s.charAt(j - 1) - '0';
+            }
+        }
+        
+        bfs(1, 1);
+    
+        System.out.println(adj[n][m]);
+    }
+}

--- a/week03/BOJ_2178_미로_탐색/김민경.java
+++ b/week03/BOJ_2178_미로_탐색/김민경.java
@@ -15,6 +15,7 @@ public class Main {
     static void bfs(int i, int j) {
         Queue<int[]> queue = new LinkedList<>();
 		queue.offer(new int[] {i, j});
+        visited[i][j] = true;
         
         while(!queue.isEmpty()) {
             int q[] = queue.poll();


### PR DESCRIPTION
### 사용한 자료구조 및 알고리즘
그래프, BFS

### 코드설명
`bfs(1, 1);`
bfs 함수를 호출한다. 시작 위치는 (1, 1)

**BFS**
```
static void bfs(int i, int j) {
        Queue<int[]> queue = new LinkedList<>();
		queue.offer(new int[] {i, j});
		visited[i][j] = true;
        
        while(!queue.isEmpty()) {
            int q[] = queue.poll();
            int qx = q[0];
            int qy = q[1];

            for(int k = 0; k < 4; k++) {
                int x = qx + dx[k]; //상하
                int y = qy + dy[k]; //좌우
                    
                if(x > 0 && y > 0 && x <= n && y <= m) {
                    if(visited[x][y] == false && adj[x][y] == 1) {
                        queue.offer(new int[] {x, y});
        		        adj[x][y] = adj[qx][qy] + 1;
                		visited[x][y] = true;
                    }
                }
            }
        }
    }    
```

```
Queue<int[]> queue = new LinkedList<>();
queue.offer(new int[] {i, j});
```
1차원 배열을 가지는 큐를 선언하고 현재 위치를 큐에 삽입하고 방문 표시를 한다.

큐가 비어있을 때까지 반복문을 돌리며 상하좌우를 탐색한다.
`if(x > 0 && y > 0 && x <= n && y <= m)` 인덱스 조건과 
`if(visited[x][y] == false && adj[x][y] == 1)`
방문하지 않았거나 이동할 수 있는 칸(1)일 경우 
```
queue.offer(new int[] {x, y});
visited[x][y] = true;
```
현재 위치를 queue에 추가하고 방문 표시를 한다.

`adj[x][y] = adj[qx][qy] + 1;`
현재 위치 = 큐에서 꺼낸 위치 + 1 (한 칸 이동한 위치)

`System.out.println(adj[n][m]);`
(1, 1)에서 출발하여 (N, M)의 위치로 이동할 때 지나야 하는 최소의 칸 수를 출력한다.

### 코드 리뷰 요청 사항

### 문제 풀이 실패
 BFS에 대한 이해가 부족하고 큐의 데이터 타입을 int[]와 별도의 클래스로 설정해 정점의 위치를  저장하는 방법을 생각해 내지 못하여 인터넷을 참고하여 풀었다.
ex)
`queue.offer(new int[] {i, j});`
`q.offer(new P(x, y, k, cnt));`

비슷한 문제를 풀어보면서 개념을 확실히 이해할 수 있도록 해야겠다.

