### PR TITLE
BOJ_1068_트리 / G5 / O

### DIFF
--- a/week04/BOJ_1068_트리/강지륜.java
+++ b/week04/BOJ_1068_트리/강지륜.java
@@ -1,0 +1,65 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+	static ArrayList<ArrayList<Integer>> tree = new ArrayList<ArrayList<Integer>>();
+	static boolean[] visited;
+	static ArrayList<Integer> delTree = new ArrayList<Integer>();
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int N = Integer.parseInt(br.readLine());
+		
+		visited = new boolean[N];
+		
+		for(int i=0; i < N; i++) 
+			tree.add(new ArrayList<>());
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		for(int i=0; i < N; i++) {
+			int n = Integer.parseInt(st.nextToken());
+			
+			if (n != -1) 
+				tree.get(n).add(i);
+		}
+			
+		int delNode = Integer.parseInt(br.readLine());
+		
+		dfs(delNode);
+		
+		for(int node : delTree) {
+			tree.forEach(t -> {
+				if (t.contains(node)) {
+					int idx = t.indexOf(node);
+					t.remove(idx);
+				}
+			});
+		}
+		
+		int i = 0;
+		int result = 0;
+		for (ArrayList<Integer> list: tree) {
+			if (list.size() == 0 && ! delTree.contains(i)) 
+				result++;
+			i++;
+		}
+		System.out.print(result);
+	}
+	
+	private static void dfs(int node) {
+		
+		visited[node] = true;
+		delTree.add(node);
+		
+		for (int v : tree.get(node)) {
+			if (!visited[v])
+				dfs(v);
+		}
+		
+	}
+
+}


### PR DESCRIPTION
## 사용한 자료구조 및 알고리즘
- DFS, 재귀

## 문제 설명
- 트리에서 입력받은 **하나의 노드를 삭제** 후 **리프 노드**의 수를 구하는 문제

## 코드 설명

### 전역 변수
```java
static ArrayList<ArrayList<Integer>> tree = new ArrayList<ArrayList<Integer>>();
static boolean[] visited;
static ArrayList<Integer> delTree = new ArrayList<Integer>();
```
- 트리를 구현하기 위해 이중 리스트를 선언했습니다.
- 방문 여부 확인용으로 1차원 boolean 타입의 배열을 선언했습니다.
- 삭제된 노드를 담기 위해 integer 타입의 리스트를 선언했습니다.


### DFS 구현
```java
private static void dfs(int node) {
	visited[node] = true;
	delTree.add(node);
		
	for (int v : tree.get(node)) {
		if (!visited[v])
			dfs(v);
	}
}
```
- 삭제할 노드와 연결된 노드를 모두 탐색해야 하므로 DFS를 구현했습니다.
- 재귀 함수를 호출하면서 방문 표시를 하고 삭제된 노드를 담는 **delTree 리스트에 노드를 추가**했습니다.

## 메인 함수
```java
for(int node : delTree) {
	tree.forEach(t -> {
		if (t.contains(node)) {
			int idx = t.indexOf(node);
			t.remove(idx);
		}
	});
}
```
- 삭제된 노드 리스트를 for문으로 돌면서 만약 각 노드의 리스트 데이터 중 삭제된 노드의 데이터를 포함하고 있다면 
인덱스를 알아내 그 인덱스를 사용하여 데이터를 삭제합니다.


```java
int i = 0;
int result = 0;
for (ArrayList<Integer> list: tree) {
	if (list.size() == 0 && ! delTree.contains(i)) 
		result++;
		i++;
}
```
- for문을 사용하여 tree를 탐색하는데 이 때 tree의 **각 리스트 사이즈가 0**이고, **tree의 인덱스가 삭제된 노드 리스트에 포함되어 있지 않다면** **리프 노드**이므로 result 값을 1씩 증가합니다. 

### 코드 리뷰 요청 사항