### PR TITLE
BOJ_1068_트리 / G5 / O

### DIFF
--- a/week04/BOJ_1068_트리/김지은.java
+++ b/week04/BOJ_1068_트리/김지은.java
@@ -1,0 +1,62 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class Main {
+    static ArrayList<Integer>[] graph;
+    static boolean[] visited;
+    static int deletedNode;
+    static int leaf = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        graph = new ArrayList[n];
+        visited = new boolean[n];
+
+        for (int i = 0; i < n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        int root = -1;
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            int p = Integer.parseInt(st.nextToken());
+
+            if (p == -1) {
+                root = i;
+            } else {
+                graph[p].add(i);
+            }
+        }
+
+        deletedNode = Integer.parseInt(br.readLine());
+        graph[deletedNode].clear();
+
+        dfs(root);
+
+        System.out.println(leaf);
+    }
+
+    static void dfs(int node) {
+        visited[node] = true;
+        int nearNode = 0;
+
+        for (int v: graph[node]) {
+            if ((v != deletedNode) && !visited[v]) {
+                nearNode++;
+                dfs(v);
+            }
+        }
+
+        if (node != deletedNode && nearNode == 0) {
+            leaf++;
+        }
+    }
+}


### PR DESCRIPTION
### 사용한 자료구조 및 알고리즘
- 그래프
- DFS

### 코드 설명
1. **트리**
```java
static ArrayList<Integer>[] graph;
...
graph = new ArrayList[n];
for (int i = 0; i < n; i++) {
    graph[i] = new ArrayList<>();
}
...
for (int i = 0; i < n; i++) {
    int p = Integer.parseInt(st.nextToken());

    if (p == -1) {
        root = i;
    } else {
        graph[p].add(i);
    }
}
```
트리는 ArrayList 배열을 이용하여 표현했습니다.

2. **노드 삭제**
```java
deletedNode = Integer.parseInt(br.readLine());
graph[deletedNode].clear();
```
삭제 노드의 자손 노드를 삭제하기 위해 clear() 메서드를 이용했습니다.

3. **DFS**
```java
static void dfs(int node) {
    visited[node] = true;
    int nearNode = 0;

    for (int v: graph[node]) {
        if ((v != deletedNode) && !visited[v]) {
            nearNode++;
            dfs(v);
        }
    }

    if (node != deletedNode && nearNode == 0) {
        leaf++;
    }
}
```
노드 삭제 과정에서 삭제 노드의 자손만 삭제했기 때문에 삭제 노드를 탐색하지 않는 조건을 추가해 트리를 DFS로 탐색했습니다. 노드의 자식 노드를 카운트하는 nearNode 변수를 이용하여 nearNode가 0이 아닐 때 리프 노드를 카운트했습니다. 삭제 노드가 루트 노드일 경우를 위해 node가 deletedNode가 아니어야 한다는 조건도 추가했습니다.

4. **런타임 에러**
```java
for (int i = 0; i < n; i++) {
    graph[i] = new ArrayList<>();
    int p = Integer.parseInt(st.nextToken());

    if (p == -1) {
        root = i;
    } else {
        graph[p].add(i);
    }
}
```
처음에 graph[i]를 초기화하는 코드를 여기에 위치시켰는데 런타임 에러가 발생했습니다. 부모 노드가 자식 노드보다 작다라는 조건이 없었기 때문에 런타임 에러가 발생할 수밖에 없었습니다. 문제의 조건을 읽고 반례를 생각하는 습관을 만들어야겠다고 생각했습니다.

### 코드 리뷰 요청 사항
자유롭게 코드 리뷰 해주세요!