### PR TITLE
BOJ_2206_벽_부수고_이동하기 / G3 / O

### DIFF
--- a/week04/BOJ_2206_벽_부수고_이동하기/김지은.java
+++ b/week04/BOJ_2206_벽_부수고_이동하기/김지은.java
@@ -1,0 +1,94 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class Node {
+    int x;
+    int y;
+    int count;
+    boolean broken;
+
+    Node(int x, int y, int count, boolean broken) {
+        this.x = x;
+        this.y = y;
+        this.count = count;
+        this.broken = broken;
+    }
+}
+
+public class Main {
+    static char[][] map;
+    static boolean[][] visited;
+    static boolean[][] brokenVisited;
+    static int[] dr = {0, 1, 0, -1};
+    static int[] dc = {1, 0, -1, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        map = new char[n][m];
+        visited = new boolean[n][m];
+        brokenVisited = new boolean[n][m];
+
+        for (int i = 0; i < n; i++) {
+            String row = br.readLine();
+            for (int j = 0; j < m; j++) {
+                map[i][j] = row.charAt(j);
+            }
+        }
+
+        System.out.println(bfs(0, 0));
+    }
+
+    static int bfs(int start, int end) {
+        Queue<Node> queue = new LinkedList<>();
+
+        visited[start][end] = true;
+
+        queue.offer(new Node(start, end, 1, false));
+
+        while (!queue.isEmpty()) {
+            Node n = queue.poll();
+            int r = n.x;
+            int c = n.y;
+
+            if (r == map.length - 1 && c == map[0].length - 1) {
+                return n.count;
+            }
+
+            for (int i = 0; i < 4; i++) {
+                int nextR = r + dr[i];
+                int nextC = c + dc[i];
+
+                if (nextR >= 0 && nextR < map.length && nextC >= 0 && nextC < map[0].length) {
+                    if (map[nextR][nextC] == '0') {
+                        if (!n.broken && !visited[nextR][nextC]) {
+                            visited[nextR][nextC] = true;
+                            queue.offer(new Node(nextR, nextC, n.count + 1, false));
+                        } else if (n.broken && !brokenVisited[nextR][nextC]) {
+                            brokenVisited[nextR][nextC] = true;
+                            queue.offer(new Node(nextR, nextC, n.count + 1, true));
+                        }
+
+                    } else {
+                        if (!n.broken) {
+                            brokenVisited[nextR][nextC] = true;
+                            queue.offer(new Node(nextR, nextC, n.count + 1, true));
+                        }
+                    }
+                }
+            }
+        }
+
+        return -1;
+    }
+
+}


### PR DESCRIPTION
### 사용한 자료구조 및 알고리즘
- 그래프
- BFS

### 코드 설명
1. **맵**
```java
static char[][] map;
...
for (int i = 0; i < n; i++) {
    String row = br.readLine();
    for (int j = 0; j < m; j++) {
        map[i][j] = row.charAt(j);
    }
}
```
맵은 2차원 char형 배열로 표현했습니다. (1, 1)부터 (N, M)까지의 최단 거리를 구하는 것이기 때문에 DFS가 아닌 BFS를 사용했습니다.

2. **BFS 전체 코드**
```java
static int bfs(int x, int y) {
    Queue<Node> queue = new LinkedList<>();

    visited[start][end] = true;

    queue.offer(new Node(x, y, 1, false));

    while (!queue.isEmpty()) {
        Node n = queue.poll();
        int r = n.x;
        int c = n.y;

        if (r == map.length - 1 && c == map[0].length - 1) {
            return n.count;
        }

        for (int i = 0; i < 4; i++) {
            int nextR = r + dr[i];
            int nextC = c + dc[i];

            if (nextR >= 0 && nextR < map.length && nextC >= 0 && nextC < map[0].length) {
                if (map[nextR][nextC] == '0') {
                    if (!n.broken && !visited[nextR][nextC]) {
                        visited[nextR][nextC] = true;
                        queue.offer(new Node(nextR, nextC, n.count + 1, false));
                    } else if (n.broken && !brokenVisited[nextR][nextC]) {
                        brokenVisited[nextR][nextC] = true;
                        queue.offer(new Node(nextR, nextC, n.count + 1, true));
                    }

                } else {
                    if (!n.broken) {
                        brokenVisited[nextR][nextC] = true;
                        queue.offer(new Node(nextR, nextC, n.count + 1, true));
                    }
                }
            }
        }
    }

    return -1;
}
```
자세하게 설명하기에 앞서 BFS의 전체 코드입니다. 매개 변수로 x와 y를 받는데 이는 출발 지점의 좌표입니다. 반환값은 (N, M)에 도착할 수 있는 경우에는 최단 거리이고, (N, M)에 도착할 수 없는 경우 -1입니다.

3. **BFS - Queue 구현**
```java
Queue<Node> queue = new LinkedList<>();

visited[start][end] = true;

queue.offer(new Node(x, y, 1, false));
```
BFS를 구현하기 위해 Node를 저장하는 Queue를 선언합니다. visited에 시작 지점의 좌표를 방문했다고 표시하고, Queue에 해당 시작 지점을 나타내는 Node를 저장합니다.

```java
class Node {
    int x;
    int y;
    int count;
    boolean broken;

    Node(int x, int y, int count, boolean broken) {
        this.x = x;
        this.y = y;
        this.count = count;
        this.broken = broken;
    }
}
```
Queue에 저장되는 Node 클래스입니다. Node는 맵의 한 칸을 표현합니다. x와 y는 각각 행과 열을 의미하고 count는 방문한 순서를 의미합니다. broken은 벽을 부쉈는지 여부를 의미합니다. 벽을 부순적이 있다면 뒤에 방문하는 Node는 모두 broken이 true가 됩니다.

4. **BFS - while문**
```java
Node n = queue.poll();
int r = n.x;
int c = n.y;

if (r == map.length - 1 && c == map[0].length - 1) {
    return n.count;
}
```
큐에 저장한 노드를 poll 한 후, 해당 노드가 (N, M)인지 확인합니다. 만약에 (N, M)이라면 방문한 순서인 count를 반환합니다.

```java
static boolean[][] visited;
static boolean[][] brokenVisited;
...
if (nextR >= 0 && nextR < map.length && nextC >= 0 && nextC < map[0].length) {
    if (map[nextR][nextC] == '0') {
        if (!n.broken && !visited[nextR][nextC]) {
            visited[nextR][nextC] = true;
            queue.offer(new Node(nextR, nextC, n.count + 1, false));
        } else if (n.broken && !brokenVisited[nextR][nextC]) {
            brokenVisited[nextR][nextC] = true;
            queue.offer(new Node(nextR, nextC, n.count + 1, true));
        }

    } else {
        if (!n.broken) {
            brokenVisited[nextR][nextC] = true;
            queue.offer(new Node(nextR, nextC, n.count + 1, true));
        }
    }
}
```
방문 표시 배열은 visited(벽을 부수지 않은 경우)와 brokenVisited(벽을 부순 경우)가 필요합니다. 이유는 아래에서 설명하겠습니다. if문에서는 인근 노드가 맵의 범위를 벗어나지 않는지 확인합니다. 그리고 인근 노드가 벽인지를 확인합니다.
- 벽이 아닌 경우
    - 벽을 부순 적이 없고 visited가 false -> visited를 true로 바꾸고 큐에 노드를 삽입(broken은 false)
    - 벽을 부순적이 있고 brokenVisited가 false -> brokenVisited를 true로 바꾸고 큐에 노드를 삽입(broken은 true) 
- 벽인 경우
    - 벽을 부순 적이 없음 -> brokenVisited를 true로 바꾸고 큐에 노드를 삽입(broken은 true)

5. **FAQ**
- **DFS가 아니라 BFS를 사용하는 이유**
    DFS는 도착 지점에 도달할 수 있는지 여부를 확인할 수는 있지만 그것이 최단 거리임을 보장하지는 못하기 때문에 BFS를 사용해야 합니다.

- **방문 표시 배열을 2개 사용하는 이유**
    예를 들어, 다음과 같은 맵이 있다고 가정합니다.

    | 0 | 1 | 0 | 0 |
    |---|---|---|---|
    | 0 | 0 | 0 | 0 |
    | 0 | 0 | 0 | 1 |
    | 0 | 0 | 1 | 0 |

    만약, 방문 표시 배열이 1개만 있다면 다음과 같은 결과가 나오게 됩니다. (A: 벽을 부순 경로, B: 벽을 부수지 않은 경로, 숫자: 방문 순서)

    | 1  | A2 | A3 | A4 |
    |----|----|----|----|
    | B2 | A3 | A4 | A5 |
    | B3 | A4 | A5 | 1  |
    | B4 | A5 | 1  | 0  |
    
    코드에서 인근 노드를 탐색하는 순서가 우, 하, 좌, 상 순이기 때문에 A5에 B4가 가로막혀 더이상 진행할 수 없게 됩니다. 그렇기 때문에 실제로 최단 거리가 7이지만 -1을 출력하게 됩니다.

    위의 반례에서 알 수 있는 것은 같은 지점에 동시에 방문할 수 있다면 벽을 부수지 않은 경로가 벽을 부순 경로보다 유리하다는 점입니다. 그렇기 때문에 벽을 부수지 않은 경로와 벽을 부순 경로를 구분해줘야 하고, 이를 방문 표시 배열을 2개 사용해 구현한 것입니다.

    벽을 부수지 않은 경로들 사이의 유불리는 존재하지 않습니다. 어차피 이전에 방문했었다는 표시가 있다는 것은 현재 경로보다 더 빠른 경로가 있다는 의미이기 때문입니다. 벽을 부순 경로들 사이도 마찬가지입니다.

- **브루트포스 알고리즘을 사용하면 안되는 이유**
    BOJ_14502_연구소가 직전 문제였기 때문에 저도 처음에는 브루트포스 알고리즘을 떠올렸습니다. 하지만 맵의 최대 크기가 1000 * 1000이고, 벽을 하나 부수고 탐색해야 하는 맵의 크기도 1000 * 1000이기 때문에 시간복잡도가 O(1조)가 나오게 됩니다. 보통 O(1억)을 1초로 계산하니까 1000초라는 말도 안 되는 시간이 나오게 되므로 브루트포스 알고리즘으로는 풀 수 없습니다.

### 코드 리뷰 요청 사항
코드를 더 효율적으로 만들 수 있는 방법이 궁금합니다!