### PR TITLE
BOJ_11004_K번째_수 / S5 / O

### DIFF
--- a/week05/BOJ_11004_K번째_수/강지륜.java
+++ b/week05/BOJ_11004_K번째_수/강지륜.java
@@ -36,7 +36,7 @@ public class Main {
 		if (left < right) {
 			int mid = (right + left) / 2;
 			mergeSort(left, mid);
-			mergeSort(mid+1, mid);
+			mergeSort(mid+1, right);
 			merge(left, mid, right);
 		}
 		

--- a/week05/BOJ_11004_K번째_수/강지륜.java
+++ b/week05/BOJ_11004_K번째_수/강지륜.java
@@ -1,0 +1,69 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+	static int N, K;
+	static int[] array;
+	static int[] temp;
+	
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		
+		array = new int[N];
+		temp = new int[N];
+		
+		st = new StringTokenizer(br.readLine());
+		int i = 0;
+		
+		while(st.hasMoreTokens()) 
+			array[i++] = Integer.parseInt(st.nextToken());
+		
+		mergeSort(0, N-1);
+		
+		System.out.print(array[K-1]);
+		
+	}
+	
+	static void mergeSort(int left, int right) {
+
+		if (left < right) {
+			int mid = (right + left) / 2;
+			mergeSort(left, mid);
+			mergeSort(mid+1, mid);
+			merge(left, mid, right);
+		}
+		
+	}
+	
+	static void merge(int left, int mid, int right) {
+		int l = left;		// 왼쪽 부분 리스트 시작점
+		int r = mid + 1;	// 오른쪽 부분 리스트 시작점
+		int idx = left;		// 채워넣을 배열의 인덱스
+		
+		while(l <= mid && r <= right) {
+			if (array[l] <= array[r]) 
+				temp[idx++] = array[l++];
+			else 
+				temp[idx++] = array[r++];
+		}
+		
+		if(l > mid) {
+			while (r <= right) 
+				temp[idx++] = array[r++];
+		} else {
+			while (l <= mid) 
+				temp[idx++] = array[l++];
+		}
+		
+		for(int i=0; i<=right; i++) 
+			array[i] = temp[i];
+	}
+ 
+}

--- a/week05/BOJ_11004_K번째_수/강지륜.java
+++ b/week05/BOJ_11004_K번째_수/강지륜.java
@@ -62,7 +62,7 @@ public class Main {
 				temp[idx++] = array[l++];
 		}
 		
-		for(int i=0; i<=right; i++) 
+		for(int i=left; i<=right; i++) 
 			array[i] = temp[i];
 	}
  


### PR DESCRIPTION
## 사용한 자료구조 및 알고리즘
- 병합 정렬

## 문제 설명
- N개의 수를 오름차순 정렬했을 때, 앞에서부터 K번째 있는 수를 구하는 문제.

## 코드 설명

**전역 변수**
```java
static int N, K;
static int[] array;
static int[] temp;
```
- temp는 array를 분할 후 합치는 과정에서 정렬한 원소를 담을 임시 배열입니다.


**병합 정렬** 


**1. 분할**

```java
static void mergeSort(int left, int right) {

	if (left < right) {
		int mid = (right + left) / 2;
		mergeSort(left, mid);
		mergeSort(mid+1, mid);
		merge(left, mid, right);
	}
}
```
- 배열을 반복적으로 분할하여 최대한 작게 쪼개진 시점에 부분 배열에 인접한 원소들과 비교하여 정렬합니다.

**2. 정복**

```java
static void merge(int left, int mid, int right) {
	int l = left;		// 왼쪽 부분 리스트 시작점
	int r = mid + 1;	// 오른쪽 부분 리스트 시작점
	int idx = left;		// 채워넣을 배열의 인덱스
		
	while(l <= mid && r <= right) {
		if (array[l] <= array[r]) 
			temp[idx++] = array[l++];
		else 
			temp[idx++] = array[r++];
	}
		
	if(l > mid) {
		while (r <= right) 
			temp[idx++] = array[r++];
	} else {
		while (l <= mid) 
			temp[idx++] = array[l++];
	}
		
	for(int i=left; i<=right; i++) 
		array[i] = temp[i];
}
```
- 변수 l 는 왼쪽 부분 배열의 시작점이고, 변수 r는 오른쪽 부분 배열의 시작점입니다.  idx는 채워넣을 배열의 인덱스를 의미합니다.
- l이 mid보다 작거나 같고 r이 right보다 작거나 같을 경우 while문 안에 있는 코드가 반복적으로 실행됩니다. 만약 왼쪽 부분 배열의 원소가 오른쪽 부분 배열의 원소보다 작거나 같을 경우 임시 배열의 temp에 왼쪽 부분 배열의 원소를 저장하고 idx와 왼쪽 부분 배열의 인덱스 값을 1씩 증가시킵니다. 
- while문을 모두 실행 후, 한 쪽 부분 배열이 아직 남아있을 경우 남은 원소들을 temp에 저장합니다.
- 마지막으로 left부터 right까지 정렬된 임시 배열을 array에 복사합니다.

## 코드 리뷰 요청 사항
