### PR TITLE
BOJ_18870_좌표_압축 / S2 / X

### DIFF
--- a/week05/BOJ_18870_좌표_압축/김민경.java
+++ b/week05/BOJ_18870_좌표_압축/김민경.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 
 public class Main {
-        public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringBuilder sb = new StringBuilder();
         int n = Integer.parseInt(br.readLine());
@@ -28,8 +28,9 @@ public class Main {
                 index++;
             }
         }
-        for(int i=0; i<n; i++)
+        for(int i=0; i<n; i++) {
 			sb.append(hashMap.get(arr[i])+" ");
-            System.out.print(sb);
+        }
+        System.out.print(sb);
     }
 }

--- a/week05/BOJ_18870_좌표_압축/김민경.java
+++ b/week05/BOJ_18870_좌표_압축/김민경.java
@@ -1,0 +1,35 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class Main {
+        public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int n = Integer.parseInt(br.readLine());
+
+        int[] arr = new int[n];
+        HashMap<Integer, Integer> hashMap = new HashMap<>();
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < n; i++) {
+            int num = Integer.parseInt(st.nextToken());
+            arr[i] = num;
+        }
+
+        int[] sortedArr = arr.clone();
+        Arrays.sort(sortedArr);
+        int index = 0;
+        for(int i = 0; i < n; i++) {
+            if(!hashMap.containsKey(sortedArr[i])) {
+                hashMap.put(sortedArr[i], index);
+                index++;
+            }
+        }
+        for(int i=0; i<n; i++)
+			sb.append(hashMap.get(arr[i])+" ");
+            System.out.print(sb);
+    }
+}


### PR DESCRIPTION
## 사용한 자료구조 및 알고리즘
- 정렬

## 문제 설명
주어진 수 Xi를 좌표 압축한 결과 Xi > Xj를 만족하는 서로 다른 좌표 개수를 구하는 문제이다.

## 코드 설명
```
 int[] sortedArr = arr.clone();
 Arrays.sort(sortedArr);
```
입력 배열을 복사하여 오름차순으로 정렬한다.

```
        int index = 0;
        for(int i = 0; i < n; i++) {
            if(!hashMap.containsKey(sortedArr[i])) {
                hashMap.put(sortedArr[i], index);
                index++;
            }
        }
```
HashMap은 데이터를 저장할 때 키(Key)와 밸류(Value)가 짝을 이루어 저장된다.  
HashMap의 키(Key) 값은 중복될 수 없기 때문에 자동으로 덮어쓰기 되면서 value값이 update 된다.
-> containsKey 메소드를 이용해 해당 키가 이미 있는지 확인하는 것이 필요!!

hasMap(key, value)에
key -> 정렬된 값
value -> index

결과 -> 
ex) 1000 999 1000 999 1000 999
일 때
key = 999, value = 0
key = 1000, value = 1

```
for(int i=0; i<n; i++) {
			sb.append(hashMap.get(arr[i])+" ");
        }
        System.out.print(sb);
```

**시간 초과**
for문을 반복하면서 String을 하나씩 더했을 때 시간 초과가 발생하였다.
이를 StringBuilder로 고치니 해결되었다.

String 클래스 -> 문자열 변경이 불가능. 변화가 생기면 새로 객체(인스턴스)를 생성하기 때문에 성능 저하
StringBuilder 클래스 -> 문자열 변경 가능. 동일한 인스턴스에 덮어쓰므로 성능 향상

## 코드 리뷰 요청 사항
