### PR TITLE
BOJ_7568_덩치 / S5 / O

### DIFF
--- a/week06/BOJ_7568_덩치/강지륜.java
+++ b/week06/BOJ_7568_덩치/강지륜.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+	static int N;
+	static int[][] array;
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws IOException  {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		N = Integer.parseInt(br.readLine());
+		array = new int[N][2];
+		
+		StringTokenizer st;
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			array[i][0] = Integer.parseInt(st.nextToken());
+			array[i][1] = Integer.parseInt(st.nextToken());
+		}
+		
+		int cnt;
+		
+		for(int i=0; i<N; i++) {
+			cnt = 1;
+			for(int j=0; j<N; j++) {
+				if (array[i][0] < array[j][0] && array[i][1] < array[j][1])
+					cnt++;
+			}
+			sb.append(cnt).append(" ");
+		}
+		
+		System.out.println(sb);
+	}
+
+}
+


### PR DESCRIPTION
## 사용한 자료구조 및 알고리즘
- 브루트포스 알고리즘

## 문제 설명
- N명의 몸무게와 키를 바탕으로 각 사람의 덩치 등수를 계산하는 문제.
- A 와 B의 덩치가 각각 (x, y), (p, q)라고 할 때 x > p 그리고 y > q 이라면 A의 덩치가 B의 덩치보다 **더 크다**. 
- N는 2보다 작거나 같고, 50보다 크거나 같다. N의 범위가 좁아 브루트포스 알고리즘을 사용하여 문제 해결 가능.

## 코드 설명

**전역 변수**
```java
static int N;
static int[][] array;
```
- 변수 N는 전체 사람의 수를 담습니다.
- array는 각 사람의 몸무게와 키의 정보를 담고 있습니다. 
   - **array[i][0]**: 몸무게
   - **array[i][1]**: 키

**브루트포스 알고리즘 구현**
```java
int cnt;
		
for(int i=0; i<N; i++) {
	cnt = 1;
	for(int j=0; j<N; j++) {
		if (array[i][0] < array[j][0] && array[i][1] < array[j][1])
			cnt++;
	}

sb.append(cnt).append(" ");
```
- **cnt**는 각 사람의 등수를 담기 위한 변수입니다. 등수는 1부터 시작하므로 초기값을 1로 설정했습니다.
- 2중 for문을 돌면서 자기 자신의 몸무게와 키 모두 큰 사람이 존재할 경우 cnt를 1씩 증가시켰습니다.

## 코드 리뷰 요청 사항
