### PR TITLE
BOJ_13305_주유소 / S3 / O

### DIFF
--- a/week08/BOJ_13305_주유소/김지은.java
+++ b/week08/BOJ_13305_주유소/김지은.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        long[] road = new long[n - 1];
+        long[] oil = new long[n];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0 ; i < n - 1; i++) {
+            road[i] = Long.parseLong(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            oil[i] = Long.parseLong(st.nextToken());
+        }
+
+        long sum = 0;
+        long min = oil[0];
+
+        for (int i = 0; i < n - 1; i++) {
+            if (oil[i] < min) {
+                min = oil[i];
+            }
+
+            sum += (min * road[i]);
+        }
+
+        System.out.println(sum);
+
+    }
+
+}


### PR DESCRIPTION
## 사용한 자료구조 및 알고리즘
- 그리디 알고리즘

## 문제 설명
- N개의 도시에 있는 주유소의 기름 가격과 각 도시를 연결하는 도로의 길이를 바탕으로 제일 왼쪽 도시에서 제일 오른쪽 도시로 이동하는 최소 비용을 계산하는 문제

## 코드 설명
1. **최소 비용 구하기**
```java
long sum = 0;
long min = oil[0];

for (int i = 0; i < n - 1; i++) {
    if (oil[i] < min) {
        min = oil[i];
    }

    sum += (min * road[i]);
}
```
최소 비용을 구하기 위해서는 각 도시의 주유소의 기름 가격이 내림차순으로 정렬될 때를 찾으면 됩니다. 그렇기 때문에 현재 도시 주유소의 기름 가격과 지금까지의 최소 주유소의 기름 가격을 비교하여 min을 정합니다. min과 다음 도시까지의 거리를 곱하여 sum에 추가해주면 최소 비용을 구할 수 있습니다.

## 코드 리뷰 요청 사항
자유롭게 코드 리뷰 해주세요!